### PR TITLE
Support breaking out of a batch early based on plate compute

### DIFF
--- a/benchmarks/src/main/scala/tectonic/csv/ParserBenchmarks.scala
+++ b/benchmarks/src/main/scala/tectonic/csv/ParserBenchmarks.scala
@@ -106,9 +106,7 @@ class ParserBenchmarks {
     val processed = if (framework == TectonicFramework) {
       val parser =
         StreamParser[IO, Int, Int](
-          Parser(countingPlate, Parser.Config().copy(row1 = '\n', row2 = 0)))(
-          c => Chunk.singleton(c),
-          cs => Chunk.ints(cs.toArray))
+          Parser(countingPlate, Parser.Config().copy(row1 = '\n', row2 = 0)))(Chunk.singleton(_))
 
       contents.through(parser).foldMonoid
     } else {

--- a/benchmarks/src/main/scala/tectonic/json/ParserBenchmarks.scala
+++ b/benchmarks/src/main/scala/tectonic/json/ParserBenchmarks.scala
@@ -108,9 +108,7 @@ class ParserBenchmarks {
 
     val processed = if (framework == TectonicFramework) {
       val mode = if (inputMode) Parser.UnwrapArray else Parser.ValueStream
-      val parser = StreamParser(Parser(plateF, mode): IO[BaseParser[IO, List[Nothing]]])(
-        _ => Chunk.empty[Nothing],
-        _ => Chunk.empty[Nothing])
+      val parser = StreamParser(Parser(plateF, mode): IO[BaseParser[IO, List[Nothing]]])(_ => Chunk.empty[Nothing])
       contents.through(parser)
     } else {
       if (inputMode)

--- a/benchmarks/src/main/scala/tectonic/json/SkipBenchmarks.scala
+++ b/benchmarks/src/main/scala/tectonic/json/SkipBenchmarks.scala
@@ -78,9 +78,7 @@ class SkipBenchmarks {
       BlockingPool,
       ChunkSize)
 
-    val parser = StreamParser(Parser(plateF, Parser.UnwrapArray))(
-      _ => Chunk.empty[Nothing],
-      _ => Chunk.empty[Nothing])
+    val parser = StreamParser(Parser(plateF, Parser.UnwrapArray))(_ => Chunk.empty[Nothing])
 
     contents.through(parser).compile.drain.unsafeRunSync()
   }

--- a/core/src/main/scala/tectonic/ParseResult.scala
+++ b/core/src/main/scala/tectonic/ParseResult.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tectonic
+
+import cats.{Eval, Eq, Foldable, MonadError, Monoid, Semigroup}
+import cats.implicits._
+
+import scala.{Int, Nothing, Product, Serializable, StringContext}
+import scala.annotation.tailrec
+import scala.util.{Either, Left, Right}
+
+sealed trait ParseResult[+A] extends Product with Serializable {
+
+  def toEitherComplete: Either[ParseException, A] =
+    this match {
+      case ParseResult.Failure(e) =>
+        Left(e)
+
+      case ParseResult.Partial(a, remaining) =>
+        Left(ParseException(s"partial parse success producing value $a with $remaining bytes remaining", -1, -1, -1))
+
+      case ParseResult.Complete(a) =>
+        Right(a)
+    }
+}
+
+private[tectonic] sealed trait LowPriorityInstances {
+  import ParseResult.{Complete, Partial, Failure}
+
+  implicit def semigroup[A: Semigroup]: Semigroup[ParseResult[A]] =
+    new ParseResultSemigroup[A]
+
+  protected class ParseResultSemigroup[A: Semigroup] extends Semigroup[ParseResult[A]] {
+    def combine(left: ParseResult[A], right: ParseResult[A]) =
+      (left, right) match {
+        case (f @ Failure(_), _) => f
+        case (_, f @ Failure(_)) => f
+        case (Partial(a1, rem1), Partial(a2, rem2)) => Partial(a1 |+| a2, rem1 + rem2)
+        case (Partial(a1, rem), Complete(a2)) => Partial(a1 |+| a2, rem)
+        case (Complete(a2), Partial(a1, rem)) => Partial(a1 |+| a2, rem)
+        case (Complete(a1), Complete(a2)) => Complete(a1 |+| a2)
+      }
+  }
+}
+
+object ParseResult extends LowPriorityInstances {
+
+  implicit def eq[A: Eq]: Eq[ParseResult[A]] =
+    Eq instance {
+      case (Failure(e1), Failure(e2)) => e1 == e2
+      case (Partial(a1, rem1), Partial(a2, rem2)) => a1 === a2 && rem1 === rem2
+      case (Complete(a1), Complete(a2)) => a1 === a2
+      case _ => false
+    }
+
+  implicit def monoid[A: Monoid]: Monoid[ParseResult[A]] =
+    new ParseResultSemigroup[A] with Monoid[ParseResult[A]]{
+      def empty = Complete(Monoid[A].empty)
+    }
+
+  implicit val instances: MonadError[ParseResult, ParseException] with Foldable[ParseResult] =
+    new MonadError[ParseResult, ParseException] with Foldable[ParseResult] {
+
+      def pure[A](a: A): ParseResult[A] = Complete(a)
+
+      def handleErrorWith[A](fa: ParseResult[A])(f: ParseException => ParseResult[A]): ParseResult[A] =
+        fa match {
+          case Failure(e) => f(e)
+          case other => other
+        }
+
+      def raiseError[A](e: ParseException): ParseResult[A] = Failure(e)
+
+      def flatMap[A, B](fa: ParseResult[A])(f: A => ParseResult[B]): ParseResult[B] =
+        fa match {
+          case Failure(e) => Failure(e)
+
+          case Partial(a, rem1) => f(a) match {
+            case Failure(e) => Failure(e)
+            case Partial(b, rem2) => Partial(b, rem1 + rem2)
+            case Complete(b) => Partial(b, rem1)
+          }
+
+          case Complete(a) => f(a)
+        }
+
+      def tailRecM[A, B](a: A)(f: A => ParseResult[Either[A, B]]): ParseResult[B] = {
+        @tailrec
+        def loop(a: A, rem: Int): ParseResult[B] =
+          f(a) match {
+            case Failure(e) => Failure(e)
+            case Partial(Left(a), rem2) => loop(a, rem + rem2)
+            case Partial(Right(b), rem2) => Partial(b, rem + rem2)
+            case Complete(Left(a)) => loop(a, rem)
+
+            case Complete(Right(b)) =>
+              if (rem > 0)
+                Partial(b, rem)
+              else
+                Complete(b)
+          }
+
+        loop(a, 0)
+      }
+
+      def foldLeft[A, B](fa: ParseResult[A], b: B)(f: (B, A) => B): B =
+        fa match {
+          case Failure(_) => b
+          case Partial(a, _) => f(b, a)
+          case Complete(a) => f(b, a)
+        }
+
+      def foldRight[A, B](fa: ParseResult[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+        fa match {
+          case Failure(_) => lb
+          case Partial(a, _) => f(a, lb)
+          case Complete(a) => f(a, lb)
+        }
+    }
+
+  final case class Failure(e: ParseException) extends ParseResult[Nothing]
+  final case class Partial[+A](a: A, remaining: Int) extends ParseResult[A]
+  final case class Complete[+A](a: A) extends ParseResult[A]
+}

--- a/core/src/main/scala/tectonic/Signal.scala
+++ b/core/src/main/scala/tectonic/Signal.scala
@@ -18,13 +18,14 @@ package tectonic
 
 import scala.Int
 
-sealed class Signal(final val ordinal: Int)
+sealed abstract class Signal(final val ordinal: Int)
 
 object Signal {
   case object Continue extends Signal(1)
   case object SkipColumn extends Signal(2)
   case object SkipRow extends Signal(-2)
   case object Terminate extends Signal(3)
+  case object BreakBatch extends Signal(4)
 
   private val _Continue = Continue
   private val _SkipColumn = SkipColumn

--- a/core/src/main/scala/tectonic/exceptions.scala
+++ b/core/src/main/scala/tectonic/exceptions.scala
@@ -31,6 +31,14 @@ final case class IncompleteParseException(msg: String) extends Exception(msg)
 private[tectonic] case object AsyncException extends Exception with control.NoStackTrace
 
 /**
+ * This class is used to signal that we *haven't* reached the end of
+ * our particular input, but the underlying plate is reaching the end
+ * of their reasonable buffer space and is in need of a lazy page
+ * boundary upstream.
+ */
+private[tectonic] case object PartialBatchException extends Exception with control.NoStackTrace
+
+/**
  * This is a more prosaic exception which indicates that we've hit a
  * parsing error.
  */

--- a/core/src/main/scala/tectonic/json/Parser.scala
+++ b/core/src/main/scala/tectonic/json/Parser.scala
@@ -371,8 +371,6 @@ final class Parser[F[_], A] private (
       }
     }
 
-    // TODO check for BreakBatch here, there, and everywhere
-    // the trick is that we need to checkpoint *before* throwing, otherwise we loop forever
     checkForAbbrev(plate.num(at(i, j), decIndex, expIndex))
     j
   }

--- a/fs2/src/main/scala/tectonic/fs2/StreamParser.scala
+++ b/fs2/src/main/scala/tectonic/fs2/StreamParser.scala
@@ -17,19 +17,14 @@
 package tectonic
 package fs2
 
-import cats.{Foldable, Functor}
+import cats.Foldable
 import cats.effect.Sync
-import cats.evidence.As
-import cats.instances.list._
-import cats.syntax.all._
+import cats.implicits._
 
-import _root_.fs2.{Chunk, Pipe, Stream}
+import _root_.fs2.{Chunk, Pipe, Pull, Stream}
 
-import scala.{Array, Byte, List}
+import scala.{Byte, Int, None, Option, Some, Unit}
 import scala.collection.mutable
-import scala.util.Either
-
-import java.lang.{SuppressWarnings, Throwable}
 
 object StreamParser {
 
@@ -38,55 +33,68 @@ object StreamParser {
    * parser, which may be constructed effectfully. Any parse errors will be sequenced
    * into the stream as a `tectonic.ParseException`, halting consumption.
    */
-  @SuppressWarnings(Array(
-    "org.wartremover.warts.NonUnitStatements",
-    "org.wartremover.warts.Throw"))
   def apply[F[_]: Sync, A, B](
       parserF: F[BaseParser[F, A]])(
-      oneChunk: A => Chunk[B],
-      manyChunk: List[A] => Chunk[B])
-      : Pipe[F, Byte, B] = { s =>
+      chunk: A => Chunk[B])
+      : Pipe[F, Byte, B] = { in =>
 
-    Stream.eval(parserF) flatMap { parser =>
-      val init = s.chunks flatMap { chunk =>
-        val chunkF = chunk match {
-          case chunk: Chunk.ByteBuffer =>
-            covaryErr(parser.absorb(chunk.buf)).rethrow.map(oneChunk)
+    def handleResult[R](pr: ParseResult[A])(next: Int => Pull[F, B, R]): Pull[F, B, R] = pr match {
+      case ParseResult.Failure(e) =>
+        Pull.raiseError[F](e)
 
-          case Chunk.ByteVectorChunk(bv) =>
-            val manyF = bv.foldLeftBB(Sync[F].delay(new mutable.ListBuffer[A])) { (accF, buf) =>
-              accF flatMap { acc =>
-                covaryErr(parser.absorb(buf)).rethrow.map(acc += _)
+      case ParseResult.Partial(a, remaining2) =>
+        Pull.output(chunk(a)) >> next(remaining2)
+
+      case ParseResult.Complete(a) =>
+        Pull.output(chunk(a)) >> next(0)
+    }
+
+    def loop(in: Stream[F, Byte], parser: BaseParser[F, A], remaining: Int, last: Option[Int]): Pull[F, B, Unit] = {
+      // if we successfully consumed less than half of our previous chunk, don't pull the next one: just re-churn
+      if (last.map(_ / 2 < remaining).getOrElse(false)) {
+        Pull.eval(parser.continue).flatMap(handleResult(_)(loop(in, parser, _, last)))
+      } else {
+        in.pull.uncons flatMap {
+          case Some((chunk: Chunk.ByteBuffer, tail)) =>
+            Pull.eval(parser.absorb(chunk.buf)).flatMap(handleResult(_)(loop(tail, parser, _, Some(chunk.size))))
+
+          case Some((chunk @ Chunk.ByteVectorChunk(bv), tail)) =>
+            val manyF = bv.foldLeftBB(Pull.pure(0).covaryAll[F, B, Int]) { (accF, buf) =>
+              def next(remaining2: Int): Pull[F, B, Int] = {
+                if (buf.remaining() / 2 < remaining2)
+                  Pull.eval(parser.continue).flatMap(handleResult(_)(next))
+                else
+                  Pull.pure(remaining2)
+              }
+
+              accF flatMap { remaining2 =>
+                Pull.eval(parser.absorb(buf)).flatMap(handleResult(_)(r => next(r + remaining2)))
               }
             }
 
-            manyF.map(m => manyChunk(m.toList))
+            manyF flatMap { remaining =>
+              loop(tail, parser, remaining, Some(chunk.size))
+            }
 
-          case chunk =>
-            covaryErr(parser.absorb(chunk.toByteBuffer)).rethrow.map(oneChunk)
+          case Some((chunk, tail)) =>
+            Pull.eval(parser.absorb(chunk.toByteBuffer)).flatMap(handleResult(_)(loop(tail, parser, _, Some(chunk.size))))
+
+          case None =>
+            Pull.done
         }
-
-        Stream.evalUnChunk(chunkF)
       }
-
-      val finishF = covaryErr(parser.finish).rethrow.map(oneChunk)
-      init ++ Stream.evalUnChunk(finishF)
     }
+
+    val pull = Pull.eval(parserF) flatMap { parser =>
+      lazy val finishF: Pull[F, B, Unit] =
+        Pull.eval(parser.finish).flatMap(handleResult(_)(rem => if (rem <= 0) Pull.done else finishF))
+
+      loop(in, parser, 0, None) >> finishF
+    }
+
+    pull.stream
   }
 
-  def foldable[F[_]: Sync, G[_]: Foldable, A](parserF: F[BaseParser[F, G[A]]]): Pipe[F, Byte, A] = {
-    def oneChunk(ga: G[A]): Chunk[A] =
-      Chunk.buffer(ga.foldLeft(new mutable.ArrayBuffer[A])(_ += _))
-
-    def manyChunk(lga: List[G[A]]): Chunk[A] =
-      Chunk.buffer(Foldable[List].compose[G].foldLeft(lga, new mutable.ArrayBuffer[A])(_ += _))
-
-    apply(parserF)(oneChunk, manyChunk)
-  }
-
-  private[this] def covaryErr[F[_]: Functor, T, A](
-      fea: F[Either[T, A]])(
-      implicit ev: T As Throwable)
-      : F[Either[Throwable, A]] =
-    fea.map(_.left.map(ev.coerce(_)))
+  def foldable[F[_]: Sync, G[_]: Foldable, A](parserF: F[BaseParser[F, G[A]]]): Pipe[F, Byte, A] =
+    apply(parserF)(ga => Chunk.buffer(ga.foldLeft(new mutable.ArrayBuffer[A])(_ += _)))
 }

--- a/fs2/src/test/scala/tectonic/fs2/StreamParserSpecs.scala
+++ b/fs2/src/test/scala/tectonic/fs2/StreamParserSpecs.scala
@@ -45,14 +45,14 @@ class StreamParserSpecs extends Specification {
   "stream parser transduction" should {
     "parse a single value" in {
       val results = Stream.chunk(Chunk.Bytes("42".getBytes)).through(parser)
-      results.compile.toList.unsafeRunSync mustEqual List(Num("42", -1, -1), FinishRow)
+      results.compile.toList.unsafeRunSync() mustEqual List(Num("42", -1, -1), FinishRow)
     }
 
     "parse two values from a single chunk" in {
       val results = Stream.chunk(Chunk.Bytes("16 true".getBytes)).through(parser)
       val expected = List(Num("16", -1, -1), FinishRow, Tru, FinishRow)
 
-      results.compile.toList.unsafeRunSync mustEqual expected
+      results.compile.toList.unsafeRunSync() mustEqual expected
     }
 
     "parse a value split across two chunks" in {
@@ -62,7 +62,7 @@ class StreamParserSpecs extends Specification {
       val results = input.through(parser)
       val expected = List(Num("79", -1, -1), FinishRow)
 
-      results.compile.toList.unsafeRunSync mustEqual expected
+      results.compile.toList.unsafeRunSync() mustEqual expected
     }
 
     "parse two values from two chunks" in {
@@ -72,7 +72,7 @@ class StreamParserSpecs extends Specification {
       val results = input.through(parser)
       val expected = List(Num("321", -1, -1), FinishRow, Tru, FinishRow)
 
-      results.compile.toList.unsafeRunSync mustEqual expected
+      results.compile.toList.unsafeRunSync() mustEqual expected
     }
 
     "parse a value from a bytebuffer chunk" in {
@@ -81,7 +81,7 @@ class StreamParserSpecs extends Specification {
       val results = input.through(parser)
       val expected = List(Num("123", -1, -1), FinishRow)
 
-      results.compile.toList.unsafeRunSync mustEqual expected
+      results.compile.toList.unsafeRunSync() mustEqual expected
     }
 
     "parse two values from a split bytevector chunk" in {
@@ -93,7 +93,7 @@ class StreamParserSpecs extends Specification {
       val results = input.through(parser)
       val expected = List(Num("456", -1, -1), FinishRow, Tru, FinishRow)
 
-      results.compile.toList.unsafeRunSync mustEqual expected
+      results.compile.toList.unsafeRunSync() mustEqual expected
     }
   }
 }

--- a/harness/src/main/scala/tectonic/harness/RowCountHarness.scala
+++ b/harness/src/main/scala/tectonic/harness/RowCountHarness.scala
@@ -34,17 +34,11 @@ object RowCountHarness {
 
   private implicit val CS = IO.contextShift(ExecutionContext.global)
 
-  def jsonParser(mode: json.Parser.Mode): Pipe[IO, Byte, Long] = {
-    StreamParser(json.Parser(RowCountPlate[IO], mode))(
-      oneChunk = Chunk.singleton(_),
-      manyChunk = cs => Chunk.singleton(cs.sum))
-  }
+  def jsonParser(mode: json.Parser.Mode): Pipe[IO, Byte, Long] =
+    StreamParser(json.Parser(RowCountPlate[IO], mode))(Chunk.singleton(_))
 
-  def csvParser(config: csv.Parser.Config): Pipe[IO, Byte, Long] = {
-    StreamParser(csv.Parser(RowCountPlate[IO], config))(
-      oneChunk = Chunk.singleton(_),
-      manyChunk = cs => Chunk.singleton(cs.sum))
-  }
+  def csvParser(config: csv.Parser.Config): Pipe[IO, Byte, Long] =
+    StreamParser(csv.Parser(RowCountPlate[IO], config))(Chunk.singleton(_))
 
   def rowCountJson(file: Path, mode: json.Parser.Mode): IO[Long] = {
     Blocker[IO].use(io.file.readAll[IO](file, _, 16384)

--- a/test/src/main/scala/tectonic/test/csv/package.scala
+++ b/test/src/main/scala/tectonic/test/csv/package.scala
@@ -73,6 +73,12 @@ package object csv {
         val r = errorPF(e)
         (r.isSuccess, r.message)
 
+      case (ParseResult.Partial(a, remaining), _) =>
+        (false, s"left partially succeded with partial result $a and $remaining bytes remaining")
+
+      case (_, ParseResult.Partial(a, remaining)) =>
+        (false, s"right partially succeded with partial result $a and $remaining bytes remaining")
+
       case ParseResult.Failure(e) =>
         (false, s"parsed to an error, but $e was unmatched by the specified pattern")
 

--- a/test/src/main/scala/tectonic/test/csv/package.scala
+++ b/test/src/main/scala/tectonic/test/csv/package.scala
@@ -73,11 +73,8 @@ package object csv {
         val r = errorPF(e)
         (r.isSuccess, r.message)
 
-      case (ParseResult.Partial(a, remaining), _) =>
-        (false, s"left partially succeded with partial result $a and $remaining bytes remaining")
-
-      case (_, ParseResult.Partial(a, remaining)) =>
-        (false, s"right partially succeded with partial result $a and $remaining bytes remaining")
+      case ParseResult.Partial(a, remaining) =>
+        (false, s"partially succeded with partial result $a and $remaining bytes remaining")
 
       case ParseResult.Failure(e) =>
         (false, s"parsed to an error, but $e was unmatched by the specified pattern")

--- a/test/src/main/scala/tectonic/test/json/Absorbable.scala
+++ b/test/src/main/scala/tectonic/test/json/Absorbable.scala
@@ -23,10 +23,9 @@ import java.lang.String
 import java.nio.ByteBuffer
 
 import scala.{Array, Byte}
-import scala.util.Either
 
 sealed trait Absorbable[A] {
-  def absorb[B](p: BaseParser[IO, B], a: A): IO[Either[ParseException, B]]
+  def absorb[B](p: BaseParser[IO, B], a: A): IO[ParseResult[B]]
 }
 
 object Absorbable {
@@ -34,17 +33,17 @@ object Absorbable {
   def apply[A](implicit A: Absorbable[A]): Absorbable[A] = A
 
   implicit object StringAbs extends Absorbable[String] {
-    def absorb[B](p: BaseParser[IO, B], str: String): IO[Either[ParseException, B]] =
+    def absorb[B](p: BaseParser[IO, B], str: String): IO[ParseResult[B]] =
       p.absorb(str)
   }
 
   implicit object ByteBufferAbs extends Absorbable[ByteBuffer] {
-    def absorb[B](p: BaseParser[IO, B], bytes: ByteBuffer): IO[Either[ParseException, B]] =
+    def absorb[B](p: BaseParser[IO, B], bytes: ByteBuffer): IO[ParseResult[B]] =
       p.absorb(bytes)
   }
 
   implicit object BArrayAbs extends Absorbable[Array[Byte]] {
-    def absorb[B](p: BaseParser[IO, B], bytes: Array[Byte]): IO[Either[ParseException, B]] =
+    def absorb[B](p: BaseParser[IO, B], bytes: Array[Byte]): IO[ParseResult[B]] =
       p.absorb(bytes)
   }
 }

--- a/test/src/main/scala/tectonic/test/json/package.scala
+++ b/test/src/main/scala/tectonic/test/json/package.scala
@@ -73,6 +73,12 @@ package object json {
       case (ParseResult.Complete(_), ParseResult.Complete(_)) =>
         (false, s"blergh", s"input parsed successfully (expected failure)")
 
+      case (ParseResult.Partial(a, remaining), _) =>
+        (false, "", s"left partially succeded with partial result $a and $remaining bytes remaining")
+
+      case (_, ParseResult.Partial(a, remaining)) =>
+        (false, "", s"right partially succeded with partial result $a and $remaining bytes remaining")
+
       case (ParseResult.Failure(err), _) =>
         (err == expected, s"input failed to parse and $err == $expected", s"input failed to parse but $err != $expected")
 

--- a/test/src/main/scala/tectonic/test/json/package.scala
+++ b/test/src/main/scala/tectonic/test/json/package.scala
@@ -24,7 +24,6 @@ import org.specs2.matcher.{Matcher, MatchersImplicits}
 import tectonic.json.Parser
 
 import scala.{List, StringContext}
-import scala.util.{Left, Right}
 
 package object json {
   private object MatchersImplicits extends MatchersImplicits
@@ -45,14 +44,14 @@ package object json {
     } yield (left, right)
 
     resultsF.unsafeRunSync() match {
-      case (Right(init), Right(tail)) =>
+      case (ParseResult.Complete(init), ParseResult.Complete(tail)) =>
         val results = init ++ tail
         (results == expected.toList, s"$results != ${expected.toList}")
 
-      case (Left(err), _) =>
+      case (ParseResult.Failure(err), _) =>
         (false, s"failed to parse with error '${err.getMessage}' at ${err.line}:${err.col} (i=${err.index})")
 
-      case (_, Left(err)) =>
+      case (_, ParseResult.Failure(err)) =>
         (false, s"failed to parse with error '${err.getMessage}' at ${err.line}:${err.col} (i=${err.index})")
     }
   }
@@ -65,13 +64,13 @@ package object json {
     } yield (left, right)
 
     resultsF.unsafeRunSync() match {
-      case (Right(_), Right(_)) =>
+      case (ParseResult.Complete(_), ParseResult.Complete(_)) =>
         (false, s"blergh", s"input parsed successfully (expected failure)")
 
-      case (Left(err), _) =>
+      case (ParseResult.Failure(err), _) =>
         (err == expected, s"input failed to parse and $err == $expected", s"input failed to parse but $err != $expected")
 
-      case (_, Left(err)) =>
+      case (_, ParseResult.Failure(err)) =>
         (err == expected, s"input failed to parse and $err == $expected", s"input failed to parse but $err != $expected")
 
     }

--- a/test/src/main/scala/tectonic/test/json/package.scala
+++ b/test/src/main/scala/tectonic/test/json/package.scala
@@ -48,6 +48,12 @@ package object json {
         val results = init ++ tail
         (results == expected.toList, s"$results != ${expected.toList}")
 
+      case (ParseResult.Partial(a, remaining), _) =>
+        (false, s"left partially succeded with partial result $a and $remaining bytes remaining")
+
+      case (_, ParseResult.Partial(a, remaining)) =>
+        (false, s"right partially succeded with partial result $a and $remaining bytes remaining")
+
       case (ParseResult.Failure(err), _) =>
         (false, s"failed to parse with error '${err.getMessage}' at ${err.line}:${err.col} (i=${err.index})")
 

--- a/test/src/test/scala/tectonic/json/ParserSpecs.scala
+++ b/test/src/test/scala/tectonic/json/ParserSpecs.scala
@@ -22,7 +22,7 @@ import cats.implicits._
 
 import org.specs2.mutable.Specification
 
-import tectonic.test.{Event, ReifiedTerminalPlate}
+import tectonic.test.{beComplete, Event, ReifiedTerminalPlate}
 import tectonic.test.json._
 
 import scala.{Array, Boolean, Byte, Int, List, Nil, Unit, Predef}, Predef._
@@ -166,10 +166,10 @@ class ParserSpecs extends Specification {
         def skipped(bytes: Int) = ()
       }), Parser.ValueStream).unsafeRunSync()
 
-      parser.absorb("42").unsafeRunSync() must beRight(())
+      parser.absorb("42").unsafeRunSync() must beComplete(())
       calls.toList mustEqual List(false)
 
-      parser.finish.unsafeRunSync() must beRight(())
+      parser.finish.unsafeRunSync() must beComplete(())
       calls.toList mustEqual List(false, true)
     }
 
@@ -197,13 +197,13 @@ class ParserSpecs extends Specification {
         def skipped(bytes: Int) = ()
       }), Parser.ValueStream).unsafeRunSync()
 
-      parser.absorb("\"h").unsafeRunSync() must beRight(())
+      parser.absorb("\"h").unsafeRunSync() must beComplete(())
       calls.toList mustEqual List(false)
 
-      parser.absorb("i\"").unsafeRunSync() must beRight(())
+      parser.absorb("i\"").unsafeRunSync() must beComplete(())
       calls.toList mustEqual List(false, false)
 
-      parser.finish.unsafeRunSync() must beRight(())
+      parser.finish.unsafeRunSync() must beComplete(())
       calls.toList mustEqual List(false, false, true)
     }
 
@@ -362,9 +362,9 @@ class ParserSpecs extends Specification {
 
       val (first, second, third) = eff.unsafeRunSync()
 
-      first must beRight(List(Skipped(3)))
-      second must beRight(expected)
-      third must beRight(Nil: List[Event])
+      first must beComplete(List(Skipped(3)))
+      second must beComplete(expected)
+      third must beComplete(Nil: List[Event])
     }
   }
 
@@ -385,7 +385,7 @@ class ParserSpecs extends Specification {
       val ioa = for {
         parser <- Parser[IO, Unit](IO.pure(NullPlate), Parser.ValueStream)
         _ <- parser.absorb(front)
-        _ <- replicate(parser.absorb(middle).rethrow, middleCount)
+        _ <- replicate(parser.absorb(middle).map(_.toEitherComplete).rethrow, middleCount)
         _ <- parser.absorb(end)
 
         len <- IO(parser.unsafeLen())


### PR DESCRIPTION
This turned out to be WAY more complicated than I thought it would be…

Part of the tricky thing here is, when the state machine receives a `Partial` result, how many times should it `continue`? and should it `continue` at all? The semantic right now is to halve the previous chunk. If the previously-seen chunk is more than twice the remaining bytes, then it will pull the next chunk and `absorb` it. Otherwise, it will `continue` as many times as necessary to get down to that level.

Loops are avoided because `BreakBatch` is a *hint*, and even if a plate breaks as often as it possibly can, it still will make *some* progress.

All of the complexity here is in doing that looping appropriately, particularly when in `ByteVectorChunk`, without causing extra copying or such. Note that I fully removed the `manyChunk` mechanism. It was technically possible to have kept it, and I did *try* to do that at first, but it created a lot of extra complexity due to the added thresholding and batching, and I'm still not convinced it's a good idea.